### PR TITLE
Fix race condition

### DIFF
--- a/minesddm/Main.qml
+++ b/minesddm/Main.qml
@@ -36,6 +36,28 @@ Rectangle {
     property var actionKeys: Object.keys(root.actionMap)
     property int currentActionIndex: 0
 
+    property bool sessionsInitialized: false
+
+    function getSessionName() {
+        if (!sessionsInitialized) {
+            return "Loading sessions...";
+        }
+        if (sessions.length === 0 || sessionIndex < 0 || sessionIndex >= sessions.length) {
+            return "No sessions found";
+        }
+        return sessions[sessionIndex].name;
+    }
+
+    function getSessionComment() {
+        if (!sessionsInitialized) {
+            return "Please wait while available desktop sessions are being loaded...";
+        }
+        if (sessions.length === 0 || sessionIndex < 0 || sessionIndex >= sessions.length) {
+            return "No session information available";
+        }
+        return sessions[sessionIndex].comment;
+    }
+
     function replacePlaceholders(text, placeholders) {
         let result = text;
         for (let key in placeholders) {
@@ -148,7 +170,7 @@ Rectangle {
             spacing: config.labelFieldSpacing
 
             CustomButton {
-                text: "Session: " + root.sessions[root.sessionIndex].name
+                text: "Session: " + root.getSessionName()
                 onCustomClicked: {
                     root.sessionIndex = (root.sessionIndex + 1) % sessionModel.count;
                 }
@@ -159,13 +181,12 @@ Rectangle {
 
                 SessionHandler {
                     // Please look at the SessionHandler.qml file to understand what is happening here
-
                 }
 
             }
 
             CustomText {
-                text: root.sessions[root.sessionIndex].comment
+                text: root.getSessionComment()
                 wrapMode: Text.Wrap
                 width: config.inputWidth
             }

--- a/minesddm/components/SessionHandler.qml
+++ b/minesddm/components/SessionHandler.qml
@@ -18,10 +18,12 @@ ListView {
                 "name": model.name,
                 "comment": model.comment
             });
+            
             // For some reason I need to update the root.sessionIndex for the values on the root.session to update and appear where they are used
             root.sessionIndex = (root.sessionIndex + 1) % sessionModel.count;
             root.sessionIndex = sessionModel.lastIndex;
+
+            root.sessionsInitialized = true;
         }
     }
-
 }


### PR DESCRIPTION
Where sessions wouldn't be loaded before the session button would be initialized leaving the button blank.

Also added information for when no session is found, even if it is an unlikely case.

Current behavior:
![image](https://github.com/user-attachments/assets/537729b7-20fd-4024-a0ce-6ca095520658)

Patched/Expected:
![image](https://github.com/user-attachments/assets/afe0dfba-0d5d-45fa-92df-62cd117d5c8c)

