### PR TITLE
Add settings option for the session text

### DIFF
--- a/minesddm/Main.qml
+++ b/minesddm/Main.qml
@@ -170,7 +170,9 @@ Rectangle {
             spacing: config.labelFieldSpacing
 
             CustomButton {
-                text: "Session: " + root.getSessionName()
+                text: root.replacePlaceholders(config.sessionText, {
+                    "session": root.getSessionName()
+                })
                 onCustomClicked: {
                     root.sessionIndex = (root.sessionIndex + 1) % sessionModel.count;
                 }

--- a/minesddm/theme.conf
+++ b/minesddm/theme.conf
@@ -51,6 +51,7 @@ passwordBottomLabel = " "
 # COMMENT the option bellow to only show the botton label if the password is not empty
 # UNCOMMENT the option bellow to always show the botton label
 # passwordBottomLabelAlways = foo
+sessionText = "Session: {session}"
 
 ##############
 # Resolution #


### PR DESCRIPTION
Add a new setting option to set the text used in the session display/selector. This option contains a placeholder to insert the session name