### PR TITLE
Tweaks for NixOS Compatability

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     }) // {
       nixosModules.default = { config, pkgs, lib, ... }:
       let
-        cfg = config.services.xserver.displayManager.sddm;
+        cfg = config.services.displayManager.sddm;
         isMinesddmTheme = (cfg.theme == "minesddm") ||
                            (cfg.settings.Theme.Current == "minesddm");
       in {

--- a/minesddm/metadata.desktop
+++ b/minesddm/metadata.desktop
@@ -16,4 +16,4 @@ Theme-Id=minesddm-theme
 Theme-API=2.0
 Website=https://github.com/Davi-S/sddm-theme-minesddm
 Version=1.0.0
-QtVersion=6
+QtVersion=5


### PR DESCRIPTION
## Commit 1: 
- Updated the cfg value to match the newer version that does not have the xserver attribute key. 
- services.xserver.displayManager.sddm is depreciated and has changed to services.displayManager.sddm.

## Commit 2: 
- Downgraded qt version from 6 to 5. 
- The merge from @Squamto breaks compatibility with NixOS packages.
- Nixpkgs still does not have qtquickcontrols2 or qtgraphicaleffects for qt6. 
- With the qt6.qt5compat and the qt5 versions of qtquickcontrols2 and qtgraphicaleffects, the derivation builds but the theme does not properly apply

## Misc. Notes:
- I am not an expert in using qt, so there may be fixes to this I do not know of. All I do know is it seemed out of place to still require qt5 packages for a .desktop service with qt version 6
- If the qt6 .desktop file still works fine with other distros, I can see if I can make a custom nix version of the desktop file, and possibly work on the nix managed theme.conf mention in an issue. 
- Hope this helps