### PR TITLE
Refactor formatter to use regex

### DIFF
--- a/minesddm/components/Formatter.qml
+++ b/minesddm/components/Formatter.qml
@@ -124,9 +124,8 @@ QtObject {
         // try to replace it if it is a placeholder
         const qMarkIndex = content.indexOf('?');
         let conditionStr = content.substring(0, qMarkIndex);
-        const conditionKey = `{${conditionStr}}`;
-        if (placeholderMap.has(conditionKey)) {
-            conditionStr = placeholderMap.get(conditionKey);
+        if (placeholderMap.has(conditionStr)) {
+            conditionStr = placeholderMap.get(conditionStr);
         }
 
         // splits the rest of the content on ":" into

--- a/minesddm/components/Formatter.qml
+++ b/minesddm/components/Formatter.qml
@@ -4,31 +4,86 @@ QtObject {
     readonly property string escapeCharacter: "%" // also change the explanation in config file accordingly, if you change this
     required property var placeholderMap
 
-    function formatString(text) {
-        // Helper function to escape special characters for use in a RegExp
-        function escapeRegExp(string) {
-            return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        }
+    // Helper function to escape special characters for use in a RegExp
+    function escapeRegExp(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
 
-        // --- 1. Pre-processing (No changes needed here) ---
-        const uniqueId = Date.now().toString(36) + Math.random().toString(36).substring(2);
-        const escapeMap = {
+    // Generate a unique ID for escape sequences
+    function generateUniqueId() {
+        return Date.now().toString(36) + Math.random().toString(36).substring(2);
+    }
+
+    // Create escape map for pre-processing
+    function createEscapeMap(uniqueId) {
+        return {
             '%%': `__PERCENT_${uniqueId}__`,
             '%{': `__LEFT_BRACE_${uniqueId}__`,
             '%}': `__RIGHT_BRACE_${uniqueId}__`,
             '%?': `__QUESTION_MARK_${uniqueId}__`,
             '%:': `__COLON_${uniqueId}__`,
         };
+    }
+
+    // Pre-process text by replacing escape sequences with temporary placeholders
+    function preprocessEscapeSequences(text, escapeMap) {
         let processedText = text;
         for (const seq in escapeMap) {
             if (Object.prototype.hasOwnProperty.call(escapeMap, seq)) {
-                 const escapedSeq = escapeRegExp(seq);
-                 processedText = processedText.replace(new RegExp(escapedSeq, 'g'), escapeMap[seq]);
+                const escapedSeq = escapeRegExp(seq);
+                processedText = processedText.replace(new RegExp(escapedSeq, 'g'), escapeMap[seq]);
             }
         }
+        return processedText;
+    }
 
-        // --- 2. Evaluate templates iteratively ---
+    // Evaluate conditional expressions (ternary-like syntax with ?)
+    function evaluateConditional(content) {
+        const qMarkIndex = content.indexOf('?');
+        let conditionStr = content.substring(0, qMarkIndex);
+        const restStr = content.substring(qMarkIndex + 1);
+
+        // Look up the condition with braces
+        const conditionKey = `{${conditionStr}}`;
+        if (placeholderMap.has(conditionKey)) {
+            conditionStr = placeholderMap.get(conditionKey);
+        }
+
+        let trueVal, falseVal;
+        const colonIndex = restStr.indexOf(':');
+
+        if (colonIndex !== -1) {
+            trueVal = restStr.substring(0, colonIndex);
+            falseVal = restStr.substring(colonIndex + 1);
+        } else {
+            trueVal = restStr;
+            falseVal = '';
+        }
+
+        return conditionStr ? trueVal : falseVal;
+    }
+
+    // Evaluate simple placeholder lookup
+    function evaluatePlaceholder(content) {
+        const contentKey = `{${content}}`;
+        return placeholderMap.has(contentKey)
+            ? placeholderMap.get(contentKey)
+            : content;
+    }
+
+    // Evaluate template content (either conditional or simple placeholder)
+    function evaluateTemplateContent(content) {
+        if (content.includes('?')) {
+            return evaluateConditional(content);
+        } else {
+            return evaluatePlaceholder(content);
+        }
+    }
+
+    // Process templates iteratively from innermost to outermost
+    function processTemplates(text) {
         const innermostRegex = /\{([^{}]*)\}/;
+        let processedText = text;
 
         while (true) {
             const match = innermostRegex.exec(processedText);
@@ -37,56 +92,42 @@ QtObject {
             }
 
             const content = match[1];
-            let evaluationResult = '';
-
-            if (content.includes('?')) {
-                const qMarkIndex = content.indexOf('?');
-                let conditionStr = content.substring(0, qMarkIndex);
-                const restStr = content.substring(qMarkIndex + 1);
-
-                // --- FIX #1: Look up the condition with braces ---
-                const conditionKey = `{${conditionStr}}`;
-                if (placeholderMap.has(conditionKey)) {
-                    conditionStr = placeholderMap.get(conditionKey);
-                }
-
-                let trueVal, falseVal;
-                const colonIndex = restStr.indexOf(':');
-
-                if (colonIndex !== -1) {
-                    trueVal = restStr.substring(0, colonIndex);
-                    falseVal = restStr.substring(colonIndex + 1);
-                } else {
-                    trueVal = restStr;
-                    falseVal = '';
-                }
-                
-                if (conditionStr) {
-                    evaluationResult = trueVal;
-                } else {
-                    evaluationResult = falseVal;
-                }
-            } else {
-                // --- FIX #2: Look up the content with braces ---
-                const contentKey = `{${content}}`;
-                evaluationResult = placeholderMap.has(contentKey)
-                    ? placeholderMap.get(contentKey)
-                    : content;
-            }
+            const evaluationResult = evaluateTemplateContent(content);
 
             const start = match.index;
             const end = start + match[0].length;
             processedText = processedText.substring(0, start) + evaluationResult + processedText.substring(end);
         }
 
-        // --- 3. Post-processing (No changes needed here) ---
+        return processedText;
+    }
+
+    // Post-process text by restoring escaped sequences
+    function postprocessEscapeSequences(text, escapeMap) {
+        let processedText = text;
         for (const seq in escapeMap) {
             if (Object.prototype.hasOwnProperty.call(escapeMap, seq)) {
                 const escapedPlaceholder = escapeRegExp(escapeMap[seq]);
                 processedText = processedText.replace(new RegExp(escapedPlaceholder, 'g'), seq.charAt(1));
             }
         }
+        return processedText;
+    }
 
+    // Main formatting function that orchestrates the entire process
+    function formatString(text) {
+        const uniqueId = generateUniqueId();
+        const escapeMap = createEscapeMap(uniqueId);
+        
+        // 1. Pre-processing: handle escape sequences
+        let processedText = preprocessEscapeSequences(text, escapeMap);
+        
+        // 2. Process templates iteratively
+        processedText = processTemplates(processedText);
+        
+        // 3. Post-processing: restore escaped characters
+        processedText = postprocessEscapeSequences(processedText, escapeMap);
+        
         return processedText;
     }
 

--- a/minesddm/components/Formatter.qml
+++ b/minesddm/components/Formatter.qml
@@ -4,13 +4,13 @@ QtObject {
     // also change the explanation in config file accordingly, if you change the escapeCharacter
     readonly property string escapeCharacter: "%"
     required property var placeholderMap
-    readonly property var escapeMap: {
-        '%%': '__ESCAPED_PERCENT__',
-        '%{': '__ESCAPED_LEFT_BRACE__',
-        '%}': '__ESCAPED_RIGHT_BRACE__',
-        '%?': '__ESCAPED_QUESTION_MARK__',
-        '%:': '__ESCAPED_COLON__'
-    }
+    readonly property var escapeMap: ({
+        [escapeCharacter + escapeCharacter]: '__ESCAPED_ESCAPE_CHARACTER__',
+        [escapeCharacter + '{']: '__ESCAPED_LEFT_BRACE__',
+        [escapeCharacter + '}']: '__ESCAPED_RIGHT_BRACE__',
+        [escapeCharacter + '?']: '__ESCAPED_QUESTION_MARK__',
+        [escapeCharacter + ':']: '__ESCAPED_COLON__'
+    })
 
     // Main formatting function that orchestrates the entire process
     function formatString(text) {
@@ -145,13 +145,12 @@ QtObject {
     }
 
     // Will escape all special characters in the text
-    // "{" to "%{"
-    // "?" to "%?"
-    // etc...
+    // "{" to "<escapeCharacter>{"; "?" to "<escapeCharacter>?"; etc...
     function escapeSpecialChars(text) {
         let result = text;
-        // The '%' must be replaced first to avoid escaping the '%' in '%{' etc.
-        result = result.replace(/%/g, escapeCharacter + "%");
+        // The escape character must be replaced first to avoid escaping the escape character in "<escapeCharacter>{" etc.
+        const escapePattern = new RegExp(escapeRegExp(escapeCharacter), 'g');
+        result = result.replace(escapePattern, escapeCharacter + escapeCharacter);
         result = result.replace(/\{/g, escapeCharacter + "{");
         result = result.replace(/\}/g, escapeCharacter + "}");
         result = result.replace(/\?/g, escapeCharacter + "?");

--- a/minesddm/components/Formatter.qml
+++ b/minesddm/components/Formatter.qml
@@ -4,36 +4,42 @@ QtObject {
     // also change the explanation in config file accordingly, if you change the escapeCharacter
     readonly property string escapeCharacter: "%"
     required property var placeholderMap
+    readonly property var escapeMap: {
+        '%%': '__ESCAPED_PERCENT__',
+        '%{': '__ESCAPED_LEFT_BRACE__',
+        '%}': '__ESCAPED_RIGHT_BRACE__',
+        '%?': '__ESCAPED_QUESTION_MARK__',
+        '%:': '__ESCAPED_COLON__'
+    }
 
     // Helper function to escape special characters for use in a RegExp,
     // since replaceAll is not being accepted as a function.
-    function escapeRegExp(string) {
-        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    function escapeRegExp(text) {
+        return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 
-    // Generate a unique ID for escape sequences based on the time and random numbers
-    function generateUniqueId() {
-        return Date.now().toString(36) + Math.random().toString(36).substring(2);
+    // Will escape all special characters in the text
+    // "{" to "%{"
+    // "?" to "%?"
+    // etc...
+    function escapeRawChars(text) {
+        let result = text;
+        // The '%' must be replaced first to avoid escaping the '%' in '%{' etc.
+        result = result.replace(/%/g, escapeCharacter + "%");
+        result = result.replace(/\{/g, escapeCharacter + "{");
+        result = result.replace(/\}/g, escapeCharacter + "}");
+        result = result.replace(/\?/g, escapeCharacter + "?");
+        result = result.replace(/:/g, escapeCharacter + ":");
+        return result;
     }
 
-    // Create escape map for pre-processing
-    function createEscapeMap(uniqueId) {
-        return {
-            '%%': `__PERCENT_${uniqueId}__`,
-            '%{': `__LEFT_BRACE_${uniqueId}__`,
-            '%}': `__RIGHT_BRACE_${uniqueId}__`,
-            '%?': `__QUESTION_MARK_${uniqueId}__`,
-            '%:': `__COLON_${uniqueId}__`,
-        };
-    }
-
-    // Pre-process text by replacing escape sequences with temporary placeholders
-    function preprocessEscapeSequences(text, escapeMap) {
+    // Process text by replacing escaped characters with temporary "placeholders"
+    // that will not be processed by the Formatter
+    function hideEscapes(text) {
         let processedText = text;
         for (const seq in escapeMap) {
             if (Object.prototype.hasOwnProperty.call(escapeMap, seq)) {
-                const escapedSeq = escapeRegExp(seq);
-                processedText = processedText.replace(new RegExp(escapedSeq, 'g'), escapeMap[seq]);
+                processedText = processedText.replace(new RegExp(escapeRegExp(seq), 'g'), escapeMap[seq]);
             }
         }
         return processedText;
@@ -41,19 +47,20 @@ QtObject {
 
     // Evaluate a single conditional expression (ternary operator)
     function evaluateConditional(content) {
+        // Gets the value before the "?" as the conditional and
+        // try to replace it if it is a placeholder
         const qMarkIndex = content.indexOf('?');
         let conditionStr = content.substring(0, qMarkIndex);
-        const restStr = content.substring(qMarkIndex + 1);
-
-        // Look up the condition with braces
         const conditionKey = `{${conditionStr}}`;
         if (placeholderMap.has(conditionKey)) {
             conditionStr = placeholderMap.get(conditionKey);
         }
 
-        let trueVal, falseVal;
+        // splits the rest of the content on ":" into
+        // the value-if-true and the value-if-false
+        const restStr = content.substring(qMarkIndex + 1);
         const colonIndex = restStr.indexOf(':');
-
+        let trueVal, falseVal;
         if (colonIndex !== -1) {
             trueVal = restStr.substring(0, colonIndex);
             falseVal = restStr.substring(colonIndex + 1);
@@ -69,11 +76,16 @@ QtObject {
     function evaluatePlaceholder(content) {
         const contentKey = `{${content}}`;
         if (placeholderMap.has(contentKey)) {
-            return placeholderMap.get(contentKey);
+            let value = placeholderMap.get(contentKey);
+            // We need to escape and hide the value to ensure that if it contains
+            // especial characters, they are not flag as unmatched curly-braces 
+            // nor tried to be evaluated in the future.
+            value = escapeRawChars(value);
+            value = hideEscapes(value);
+            return value
         } else {
             showError(`Invalid placeholder: "{${content}}"`);
-            // Return empty string on error
-            return ""; 
+            return "";
         }
     }
 
@@ -90,19 +102,15 @@ QtObject {
     function processTemplates(text) {
         // This pattern finds a matched pair of curly braces that does not contain any other braces inside it
         // These are the innermost templates to work on.
-        // Placeholders will be evaluated before the ternary expressions
+        // Placeholders will usually be evaluated before the ternary expressions
         const innermostRegex = /\{([^{}]*)\}/;
         let processedText = text;
 
         while (true) {
             const match = innermostRegex.exec(processedText);
-            if (!match) {
-                break;
-            }
-
+            if (!match) break;
             const content = match[1];
             const evaluationResult = evaluateTemplateContent(content);
-
             const start = match.index;
             const end = start + match[0].length;
             // Rebuilds the original string with the placeholder value
@@ -112,13 +120,13 @@ QtObject {
         return processedText;
     }
 
-    // Post-process text by restoring escaped sequences
-    function postprocessEscapeSequences(text, escapeMap) {
+    // Process text by restoring the temporary "placeholders" created by
+    // hideEscapes into their actual values
+    function restoreEscapes(text) {
         let processedText = text;
         for (const seq in escapeMap) {
             if (Object.prototype.hasOwnProperty.call(escapeMap, seq)) {
-                const escapedPlaceholder = escapeRegExp(escapeMap[seq]);
-                processedText = processedText.replace(new RegExp(escapedPlaceholder, 'g'), seq.charAt(1));
+                processedText = processedText.replace(new RegExp(escapeRegExp(escapeMap[seq]), 'g'), seq.charAt(1));
             }
         }
         return processedText;
@@ -126,23 +134,16 @@ QtObject {
 
     // Main formatting function that orchestrates the entire process
     function formatString(text) {
-        // Check for empty/undefined input
-        if (!text) {
-            return "";
-        }
+        if (!text) return "";
 
         // Pre-processing to handle escape sequences.
         // This effectively makes the special characters invisible
         // to the main processing logic
-
-        // The point of the uniqueId is to prevent an accidental collision
-        // if the user's text also contain the same string we're using for a placeholder.
-        // This is like killing an ant with an RPG, but why not?
-        const uniqueId = generateUniqueId();
-        const escapeMap = createEscapeMap(uniqueId);
-        let processedText = preprocessEscapeSequences(text, escapeMap);
+        let processedText = hideEscapes(text);
         
-        // Process the template (do not need to care about escaped characters)
+        // Process the template
+        // This process function must receive the template without any escaped
+        // characters. This is why there is preprocessing.
         processedText = processTemplates(processedText);
         
         // Check for unmatched braces
@@ -159,8 +160,8 @@ QtObject {
             return text;
         }
         
-        // Post-processing to restore escaped characters
-        processedText = postprocessEscapeSequences(processedText, escapeMap);
+        // Post-processing to restore the temporary "placeholders"
+        processedText = restoreEscapes(processedText);
         
         return processedText;
     }


### PR DESCRIPTION
This pull request completely refactors the `formatString` logic, improving reliability and maintainability.

The previous implementation, which relied on manual index tracking, has been replaced with a regex-based approach.

*Comparison:*
- Improved readability
- Robust escape handling
- Less specific error location