### PR TITLE
Fix broken build dependency in the nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           qt5.qtbase
           qt5.qtquickcontrols2
           qt5.qtgraphicaleffects
-          libsForQt5.layer-shell-qt
+          kdePackages.layer-shell-qt
         ];
       };
     };


### PR DESCRIPTION
This fixes issue #55; I tested it, and the version on my fork works for my nix setup. 