### PR TITLE
Re-merge: Fix broken build dependency in the nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           qt5.qtbase
           qt5.qtquickcontrols2
           qt5.qtgraphicaleffects
-          libsForQt5.layer-shell-qt
+          kdePackages.layer-shell-qt
         ];
       };
     };


### PR DESCRIPTION
This is created in order to redo the merge, which was merged with main in a mistake. Refer to #56 