### PR TITLE
Replace libsForQt5.layer-shell-qt with kdePackages.layer-shell-qt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           qt5.qtbase
           qt5.qtquickcontrols2
           qt5.qtgraphicaleffects
-          libsForQt5.layer-shell-qt
+          kdePackages.layer-shell-qt
         ];
       };
     };


### PR DESCRIPTION
`layer-shell-qt` was removed from nixpkgs and now lives under `kdePackages.layer-shell-qt.`