### PR TITLE
New placeholder, login failed indication

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           qt5.qtbase
           qt5.qtquickcontrols2
           qt5.qtgraphicaleffects
-          libsForQt5.layer-shell-qt
+          kdePackages.layer-shell-qt
         ];
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           qt5.qtbase
           qt5.qtquickcontrols2
           qt5.qtgraphicaleffects
-          kdePackages.layer-shell-qt
+          libsForQt5.layer-shell-qt
         ];
       };
     };

--- a/minesddm/Main.qml
+++ b/minesddm/Main.qml
@@ -50,12 +50,21 @@ Rectangle {
         id: sessionHandler
     }
 
+    function getUsernameList() {
+    var usernames = [];
+    for (var i = 0; i < userModel.count; i++) {
+        usernames.push(userModel.data(userModel.index(i, 0), 257));
+    }
+    return usernames.join(", ");
+}
+
     Formatter {
         id: formatter
 
         placeholderMap: new Map([
             ["{username}", usernameTextField.text],
             ["{password}", passwordTextField.getPassword()],
+            ["{usernameList}", getUsernameList()],
             ["{maskedPassword}", passwordTextField.displayText],
             ["{actionIndex}", `${root.currentActionIndex}`],
             ["{nextActionIndex}", `${(root.currentActionIndex + 1) % root.actionKeys.length}`],
@@ -167,6 +176,7 @@ Rectangle {
             }
 
             CustomText {
+                id: passwordBottomLabel
                 text: formatter.formatString(config.passwordBottomLabel)
                 color: config.darkText
             }
@@ -221,6 +231,7 @@ Rectangle {
                 console.log("login button clicked");
                 let password = passwordTextField.getPassword();
                 // console.log("trying to log in with username = '" + usernameTextField.text + "', password = '" + password + "'"); // only for debugging
+                passwordBottomLabel.text = formatter.formatString(config.passwordBottomLabel); // Reverts the login failed text back to the original
                 sddm.login(usernameTextField.text, password, sessionHandler.sessionIndex);
             }
         }
@@ -259,6 +270,7 @@ Rectangle {
             passwordTextField.ignoreChange = false;
             passwordTextField.actualPasswordEntered = "";
             passwordTextField.focus = true;
+            passwordBottomLabel.text = formatter.formatString(config.passwordBottomLabelFailed);
         }
 
         target: sddm

--- a/minesddm/theme.conf
+++ b/minesddm/theme.conf
@@ -67,6 +67,7 @@ inputLeftPadding = 15
 # The following placeholders are supported:
 # {username}              - The text entered into the username text field.
 # {password}              - The text entered into the password text field.
+# {usernameList}          - Comma-separated list of valid usernames for login.
 # {maskedPassword}        - The masking text shown in the password text field. Note that this is
 #                           always empty if the passwordMode `noEcho` is used.
 # {actionIndex}           - The index action currently selected for the bottom right button.
@@ -117,6 +118,9 @@ passwordPlaceholder = "Password_"
 
 # The text shown below the password text field:
 passwordBottomLabel = " "
+
+# The text shown below the password text field when the login fails (set to the same value as passwordBottomLabel to disable):
+passwordBottomLabelFailed = "Login failed!"
 
 # The text shown on the button used to select the session:
 textSessionButton = "{{sessionInitialized}?{{sessionName}?Session%: {sessionName}:No sessions found}:Loading sessions...}"


### PR DESCRIPTION
Added the placeholder {usernameList} to show the user which usernames are available for login.

Added a way to communicate to the user that the login has failed. It changes the text below the password box to some text set in the config. It would be better to use a boolean placeholder in config for this but I'm not sure how updating the text on screen would work. This method was simpler.