### PR TITLE
fix: update libsForQt5.layer-shell-qt to kdePackages.layer-shell-qt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           qt5.qtbase
           qt5.qtquickcontrols2
           qt5.qtgraphicaleffects
-          libsForQt5.layer-shell-qt
+          kdePackages.layer-shell-qt
         ];
       };
     };


### PR DESCRIPTION
update libsForQt5.layer-shell-qt to kdePackages.layer-shell-qt for nixos-unstable compatibility