### PR TITLE
fix: update layer-shell-qt and fix pkgs.system warning for NixOS unstable/26.05 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ MineSDDM is a custom theme for [SDDM](https://wiki.archlinux.org/title/SDDM) ins
 
 - **SDDM**: Ensure that SDDM is installed and set as your system’s display manager.
 - **Qt**: Requires Qt 5.15 or later.
-- **Dependencies**: Confirm that your system has all SDDM, QT, and other system-specific dependencies installed. For example `qt5-quickcontrols2`, `layer-shell-qt5`, and `layer-shell-qt`.
+- **Dependencies**: Confirm that your system has all SDDM, QT, and other system-specific dependencies installed. For example, `qt5-quickcontrols2`, `layer-shell-qt5`, and `layer-shell-qt`.
 
-### Manual Instalation
+### Manual Installation
 
 Should work on most systems
 
@@ -36,6 +36,14 @@ Should work on most systems
 
 3. **Logout of your session**:
    Logout and you will (probably) see the new theme
+
+### AUR
+
+It is available on AUR (not maintained by me) and can be installed using any AUR helper.
+
+```
+paru -Syu sddm-minesddm-theme
+```
 
 ### NixOS Installation
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,12 +34,12 @@
                            (cfg.settings.Theme.Current == "minesddm");
       in {
         environment.systemPackages = with pkgs; [
-          self.packages.${pkgs.system}.default
+          self.packages.${pkgs.stdenv.hostPlatform.system}.default
         ] ++ lib.optionals isMinesddmTheme [
           qt5.qtbase
           qt5.qtquickcontrols2
           qt5.qtgraphicaleffects
-          libsForQt5.layer-shell-qt
+          kdePackages.layer-shell-qt
         ];
       };
     };


### PR DESCRIPTION
Hi apologies, I accidentally closed the previous pull request. This new PR includes the previous fix along with an additional update for NixOS compatibility. Here is a summary of the changes included in this PR:

1. Fix for the critical build error: As discussed before, libsForQt5.layer-shell-qt was removed in the `nixos-unstable` and `26.05` channels due to the Qt5/KDE5 package migration. Updating it to `kdePackages.layer-shell-qt` fully fixes the installation.

2. Fix for the deprecation warning: I noticed that using `pkgs.system` now triggers a persistent deprecation warning during the build process. I have updated `self.packages.${pkgs.system}.default` to `self.packages.${pkgs.stdenv.hostPlatform.system}.default` to resolve this warning.

Both changes have been tested and ensure a clean, error-free build on current NixOS configurations. 