### PR TITLE
Added NixOS settings for theme.conf

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,16 +8,38 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-      packages.default = pkgs.stdenv.mkDerivation {
+      # note for settings attr-set:
+      # { key = "value"; }     => key = value
+      # { key = "\"value\""; } => key = "value"
+      packages.default = pkgs.callPackage ({
+        lib,
+        stdenv,
+        settings ? {},
+        overwrite ? false,
+        ...
+      }: stdenv.mkDerivation rec {
         pname = "sddm-theme-minesddm";
         version = "1.0.0";
         src = ./.;
 
+        settingsText =
+          (if overwrite then ''
+            [general]
+          '' else ''
+            ${builtins.readFile "${src}/minesddm/theme.conf"}
+          '') + ''
+            ${lib.generators.toKeyValue
+              { mkKeyValue = lib.generators.mkKeyValueDefault {} " = "; }
+            settings}
+          '';
+
+        passAsFile = [ "settingsText" ];
         dontWrapQtApps = true;
 
         installPhase = ''
           mkdir -p $out/share/sddm/themes/minesddm
           cp -r minesddm/* $out/share/sddm/themes/minesddm/
+          cp $settingsTextPath $out/share/sddm/themes/minesddm/theme.conf
         '';
 
         meta = with pkgs.lib; {
@@ -25,7 +47,8 @@
           license = licenses.agpl3Only;
           platforms = platforms.linux;
         };
-      };
+      }) {};
+
     }) // {
       nixosModules.default = { config, pkgs, lib, ... }:
       let


### PR DESCRIPTION
Ok I was having branch issues with main and dev but I _think_ it should be fixed now, this was my original comment:

- append additional settings to the existing theme.conf. Section is still under [general], you cannot add any additional sections and from my knowledge, general is the only needed section (please correct me if I am wrong).
- Default settings is an empty attribute set.
- When overwrite is set to true (default is false), append general section flag, and add your own settings stuff. Default theme.conf will not be appended.
- ~libsForQt5.layer-shell-qt is deprecated so I replaced it to kdePackages.layer-shell-qt. I was not able to build with libsForQt5 but if this is an issue for anyone, I can add a commit to revert this change~ Already fixed on dev brach (woohoo!)